### PR TITLE
fix: Replace Pricing component with PricingWithStripe to enable proper Stripe checkout flow

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import Features from '@/components/Features'
 import BJJFlowChart from '@/components/BJJFlowChart'
 import HowToUse from '@/components/HowToUse'
 import SafetyAndWellness from '@/components/SafetyAndWellness'
-import Pricing from '@/components/Pricing'
+import PricingWithStripe from '@/components/PricingWithStripe'
 import Supervisor from '@/components/Supervisor'
 import FAQ from '@/components/FAQ'
 import Signup from '@/components/Signup'
@@ -24,7 +24,7 @@ export default function Home() {
         <BJJFlowChart />
         <HowToUse />
         <SafetyAndWellness />
-        <Pricing />
+        <PricingWithStripe />
         <Supervisor />
         <FAQ />
         <Signup />

--- a/src/components/PricingWithStripe.tsx
+++ b/src/components/PricingWithStripe.tsx
@@ -6,6 +6,7 @@ import { useLanguage } from '@/contexts/LanguageContext'
 import { SUBSCRIPTION_PLANS, type PlanId } from '@/lib/stripe/config'
 import { getStripe } from '@/lib/stripe/client'
 import { useAuth } from '@/hooks/useAuth'
+import toast from 'react-hot-toast'
 
 export default function PricingWithStripe() {
   const { t, language } = useLanguage()
@@ -19,7 +20,16 @@ export default function PricingWithStripe() {
     
     // Check if user is authenticated
     if (!user) {
-      router.push(`/auth/callback?redirect=/pricing&plan=${planId}`)
+      toast.error(
+        language === 'ja' ? 'サブスクリプションを購入するにはログインが必要です' :
+        language === 'en' ? 'Please log in to subscribe' :
+        'Faça login para assinar'
+      )
+      // Show login dialog
+      const loginButton = document.querySelector('[data-testid="login-button"]') as HTMLButtonElement
+      if (loginButton) {
+        loginButton.click()
+      }
       return
     }
 


### PR DESCRIPTION
Fixes ##9 - Pro plan purchase button now properly redirects to Stripe checkout instead of dashboard.

## Changes
- Replace Pricing import with PricingWithStripe in main page.tsx
- Fix authentication flow to show login dialog instead of redirect
- Add toast notification for better UX when login is required

## Testing
Verified that purchase button now properly integrates with Stripe checkout flow.

🤖 Generated with [Claude Code](https://claude.ai/code)