### PR TITLE
fix: implement client-side language switching without URL changes

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,7 +1,37 @@
+'use client'
+
 import Link from 'next/link'
 import { Home, ArrowLeft } from 'lucide-react'
+import { useLanguage } from '@/contexts/LanguageContext'
+
+const translations = {
+  ja: {
+    title: 'ページが見つかりません',
+    message: 'お探しのページは存在しないか、移動した可能性があります。',
+    homeButton: 'ホームへ戻る',
+    dashboardButton: 'ダッシュボードへ',
+    support: 'エラーが続く場合は、サポート（support@muratabjj.com）までご連絡ください。'
+  },
+  en: {
+    title: 'Page Not Found',
+    message: 'The page you are looking for does not exist or has been moved.',
+    homeButton: 'Back to Home',
+    dashboardButton: 'To Dashboard',
+    support: 'If the error persists, please contact support (support@muratabjj.com).'
+  },
+  pt: {
+    title: 'Página Não Encontrada',
+    message: 'A página que você está procurando não existe ou foi movida.',
+    homeButton: 'Voltar ao Início',
+    dashboardButton: 'Para o Painel',
+    support: 'Se o erro persistir, entre em contato com o suporte (support@muratabjj.com).'
+  }
+}
 
 export default function NotFound() {
+  const { language } = useLanguage()
+  const t = translations[language as keyof typeof translations] || translations.ja
+
   return (
     <div className="min-h-screen bg-bjj-bg flex items-center justify-center px-4">
       <div className="text-center max-w-md">
@@ -10,11 +40,11 @@ export default function NotFound() {
         </div>
         
         <h1 className="text-3xl font-bold mb-4 text-bjj-text">
-          ページが見つかりません
+          {t.title}
         </h1>
         
         <p className="text-bjj-muted mb-8">
-          お探しのページは存在しないか、移動した可能性があります。
+          {t.message}
         </p>
         
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
@@ -23,7 +53,7 @@ export default function NotFound() {
             className="btn-primary flex items-center justify-center gap-2"
           >
             <Home className="w-5 h-5" />
-            ホームへ戻る
+            {t.homeButton}
           </Link>
           
           <Link
@@ -31,13 +61,13 @@ export default function NotFound() {
             className="btn-ghost flex items-center justify-center gap-2"
           >
             <ArrowLeft className="w-5 h-5" />
-            ダッシュボードへ
+            {t.dashboardButton}
           </Link>
         </div>
         
         <div className="mt-12 p-6 bg-white/5 rounded-bjj border border-white/10">
           <p className="text-sm text-bjj-muted">
-            エラーが続く場合は、サポート（support@muratabjj.com）までご連絡ください。
+            {t.support}
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Fixed language switching issues that were causing 404 errors and language persistence problems.

### Changes Made

**LanguageContext.tsx**
- Removed URL manipulation that added /en or /pt prefixes
- Implemented client-side only language switching
- Improved localStorage persistence with murata-bjj-locale key
- Better SSR handling to prevent hydration mismatches

**not-found.tsx**
- Converted to client component with full localization
- Support for ja/en/pt languages in 404 page
- Dynamic language selection using LanguageContext

### Root Cause

The issue was caused by two competing internationalization systems:
1. URL-based routing with /[locale]/ expecting /en/dashboard URLs
2. Client-side language switching trying to work without URL changes

### Solution

- Language switching now only changes UI text, not URLs
- Settings persist via localStorage across navigation
- All dashboard links work regardless of selected language
- 404 pages show in correct language

### Testing

✅ Language switching no longer adds URL prefixes
✅ Navigation links work after language change
✅ Language settings persist across navigation
✅ 404 pages display in selected language
✅ No more broken dashboard navigation

Fixes # Issue #8

🤖 Generated with [Claude Code](https://claude.ai/code)